### PR TITLE
Removed division by 1000 as duration is already in ms

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ if (!console._sketch) {
 
     var duration = Date.now() - timers[label]
     delete timers[label]
-    return logEverywhere('log', [label + ': ' + (duration / 1000) + 'ms'])
+    return logEverywhere('log', [label + ': ' + duration + 'ms'])
   }
 
   // console.trace = function() {}


### PR DESCRIPTION
Hi @mathieudutour,

I was trying to measure some slow code in my plugin and came across some weird results from console.time.
I was getting code taking ms where I was expecting it to take seconds.

So I did a quick test:
```
console.time('1 second'); 
setTimeout(() => {
   console.timeEnd('1 second');
}, 1000); 
console.time('1 ms'); 
setTimeout(() => {
  console.timeEnd('1 ms'); 
}, 1);
```
And got the following output:
```
'1 ms: 0.002ms'
'1 second: 1.001ms'
```

This leads me to believe that the division by 1000 is unneeded.